### PR TITLE
Fix "RuntimeError: PyTorch was compiled without NumPy support"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ install_requires =
     click
     click_default_group
     torch==0.4.0; python_version == "3.6"
-    torch==0.4.1; python_version == "3.7"
+    torch==0.4.1.post2; python_version == "3.7"
     torchvision==0.2.1
     prompt_toolkit
     tqdm


### PR DESCRIPTION
Occurs when calling utilities.evaluation_utils.metrics_computations.py:compute_metric_results with Python 3.7

cf. https://github.com/HazyResearch/metal/issues/101