### PR TITLE
Collapse duplicate code for `_compute_loss`

### DIFF
--- a/src/pykeen/kge_models/base.py
+++ b/src/pykeen/kge_models/base.py
@@ -5,6 +5,7 @@
 from dataclasses import dataclass
 from typing import Dict, Optional, Union
 
+import numpy as np
 import torch
 from torch import nn
 
@@ -90,6 +91,18 @@ class BaseModule(nn.Module):
 
     def _get_entity_embeddings(self, entities):
         return self.entity_embeddings(entities).view(-1, self.embedding_dim)
+
+    def _compute_loss(self, positive_scores: torch.Tensor, negative_scores: torch.Tensor) -> torch.Tensor:
+        y = np.repeat([-1], repeats=positive_scores.shape[0])
+        y = torch.tensor(y, dtype=torch.float, device=self.device)
+
+        # Scores for the psotive and negative triples
+        positive_scores = torch.tensor(positive_scores, dtype=torch.float, device=self.device)
+        negative_scores = torch.tensor(negative_scores, dtype=torch.float, device=self.device)
+        # neg_scores_temp = 1 * torch.tensor(neg_scores, dtype=torch.float, device=self.device)
+
+        loss = self.criterion(positive_scores, negative_scores, y)
+        return loss
 
 
 def slice_triples(triples):

--- a/src/pykeen/kge_models/distmult.py
+++ b/src/pykeen/kge_models/distmult.py
@@ -68,20 +68,6 @@ class DistMult(BaseModule):
         loss = self._compute_loss(positive_scores=positive_scores, negative_scores=negative_scores)
         return loss
 
-    def _compute_loss(self, positive_scores, negative_scores):
-        # Choose y = -1 since a smaller score is better.
-        # In TransE for example, the scores represent distances
-        y = np.repeat([-1], repeats=positive_scores.shape[0])
-        y = torch.tensor(y, dtype=torch.float, device=self.device)
-
-        # Scores for the psotive and negative triples
-        positive_scores = torch.tensor(positive_scores, dtype=torch.float, device=self.device)
-        negative_scores = torch.tensor(negative_scores, dtype=torch.float, device=self.device)
-        # neg_scores_temp = 1 * torch.tensor(neg_scores, dtype=torch.float, device=self.device)
-
-        loss = self.criterion(positive_scores, negative_scores, y)
-        return loss
-
     def _score_triples(self, triples):
         head_embeddings, relation_embeddings, tail_embeddings = self._get_triple_embeddings(triples)
         return self._compute_scores(head_embeddings, relation_embeddings, tail_embeddings)

--- a/src/pykeen/kge_models/ermlp.py
+++ b/src/pykeen/kge_models/ermlp.py
@@ -4,7 +4,6 @@
 
 from typing import Dict
 
-import numpy as np
 import torch
 import torch.autograd
 from torch import nn
@@ -51,19 +50,7 @@ class ERMLP(BaseModule):
     def forward(self, positives, negatives):
         positive_scores = self._score_triples(positives)
         negative_scores = self._score_triples(negatives)
-        loss = self._compute_loss(positive_scores, negative_scores)
-        return loss
-
-    def _compute_loss(self, positive_scores, negative_scores):
-        y = np.repeat([-1], repeats=positive_scores.shape[0])
-        y = torch.tensor(y, dtype=torch.float, device=self.device)
-
-        # Scores for the psotive and negative triples
-        positive_scores = torch.tensor(positive_scores, dtype=torch.float, device=self.device)
-        negative_scores = torch.tensor(negative_scores, dtype=torch.float, device=self.device)
-        # neg_scores_temp = 1 * torch.tensor(neg_scores, dtype=torch.float, device=self.device)
-
-        loss = self.criterion(positive_scores, negative_scores, y)
+        loss = self._compute_loss(positive_scores=positive_scores, negative_scores=negative_scores)
         return loss
 
     def _score_triples(self, triples):

--- a/src/pykeen/kge_models/rescal.py
+++ b/src/pykeen/kge_models/rescal.py
@@ -48,20 +48,7 @@ class RESCAL(BaseModule):
     def forward(self, positives, negatives):
         positive_scores = self._score_triples(positives)
         negative_scores = self._score_triples(negatives)
-        loss = self._compute_loss(positive_scores, negative_scores)
-        return loss
-
-    def _compute_loss(self, positive_scores, negative_scores):
-        # TODO: Check
-        y = np.repeat([-1], repeats=positive_scores.shape[0])
-        y = torch.tensor(y, dtype=torch.float, device=self.device)
-
-        # Scores for the psotive and negative triples
-        positive_scores = torch.tensor(positive_scores, dtype=torch.float, device=self.device)
-        negative_scores = torch.tensor(negative_scores, dtype=torch.float, device=self.device)
-        # neg_scores_temp = 1 * torch.tensor(neg_scores, dtype=torch.float, device=self.device)
-
-        loss = self.criterion(positive_scores, negative_scores, y)
+        loss = self._compute_loss(positive_scores=positive_scores, negative_scores=negative_scores)
         return loss
 
     def _score_triples(self, triples):

--- a/src/pykeen/kge_models/rescal.py
+++ b/src/pykeen/kge_models/rescal.py
@@ -4,7 +4,6 @@
 
 from typing import Dict
 
-import numpy as np
 import torch
 import torch.autograd
 from torch import nn

--- a/src/pykeen/kge_models/structured_embedding.py
+++ b/src/pykeen/kge_models/structured_embedding.py
@@ -80,18 +80,7 @@ class StructuredEmbedding(BaseModule):
         positive_scores = self._score_triples(positives)
         negative_scores = self._score_triples(negatives)
 
-        loss = self._compute_loss(positive_scores, negative_scores)
-        return loss
-
-    def _compute_loss(self, positive_scores, negative_scores):
-        y = np.repeat([-1], repeats=positive_scores.shape[0])
-        y = torch.tensor(y, dtype=torch.float, device=self.device)
-
-        # Scores for the positive and negative triples
-        positive_scores = torch.tensor(positive_scores, dtype=torch.float, device=self.device)
-        negative_scores = torch.tensor(negative_scores, dtype=torch.float, device=self.device)
-
-        loss = self.criterion(positive_scores, negative_scores, y)
+        loss = self._compute_loss(positive_scores=positive_scores, negative_scores=negative_scores)
         return loss
 
     def _score_triples(self, triples):

--- a/src/pykeen/kge_models/trans_d.py
+++ b/src/pykeen/kge_models/trans_d.py
@@ -5,7 +5,6 @@
 from dataclasses import dataclass
 from typing import Dict
 
-import numpy as np
 import torch
 import torch.autograd
 from torch import nn

--- a/src/pykeen/kge_models/trans_d.py
+++ b/src/pykeen/kge_models/trans_d.py
@@ -72,25 +72,10 @@ class TransD(BaseModule):
         scores = self._score_triples(triples)
         return scores.detach().cpu().numpy()
 
-    def _compute_loss(self, positive_scores, negative_scores):
-        # y == -1 indicates that second input to criterion should get a larger loss
-        # y = torch.Tensor([-1]).cuda()
-        # NOTE: y = 1 is important
-        # y = torch.tensor([-1], dtype=torch.float, device=self.device)
-        y = np.repeat([-1], repeats=positive_scores.shape[0])
-        y = torch.tensor(y, dtype=torch.float, device=self.device)
-
-        # Scores for the psotive and negative triples
-        positive_scores = torch.tensor(positive_scores, dtype=torch.float, device=self.device)
-        negative_scores = torch.tensor(negative_scores, dtype=torch.float, device=self.device)
-
-        loss = self.criterion(positive_scores, negative_scores, y)
-        return loss
-
     def forward(self, positives, negatives):
         positive_scores = self._score_triples(positives)
         negative_scores = self._score_triples(negatives)
-        loss = self._compute_loss(positive_scores, negative_scores)
+        loss = self._compute_loss(positive_scores=positive_scores, negative_scores=negative_scores)
         return loss
 
     def _score_triples(self, triples):

--- a/src/pykeen/kge_models/trans_e.py
+++ b/src/pykeen/kge_models/trans_e.py
@@ -97,17 +97,6 @@ class TransE(BaseModule):
         loss = self._compute_loss(positive_scores=positive_scores, negative_scores=negative_scores)
         return loss
 
-    def _compute_loss(self, positive_scores, negative_scores):
-        y = np.repeat([-1], repeats=positive_scores.shape[0])
-        y = torch.tensor(y, dtype=torch.float, device=self.device)
-
-        # Scores for the positive and negative triples
-        positive_scores = torch.tensor(positive_scores, dtype=torch.float, device=self.device)
-        negative_scores = torch.tensor(negative_scores, dtype=torch.float, device=self.device)
-
-        loss = self.criterion(positive_scores, negative_scores, y)
-        return loss
-
     def _score_triples(self, triples):
         head_embeddings, relation_embeddings, tail_embeddings = self._get_triple_embeddings(triples)
         scores = self._compute_scores(head_embeddings, relation_embeddings, tail_embeddings)

--- a/src/pykeen/kge_models/trans_h.py
+++ b/src/pykeen/kge_models/trans_h.py
@@ -170,6 +170,6 @@ class TransH(BaseModule):
         pos_scores = self._compute_scores(h_embs=projected_heads_pos, r_embs=pos_rel_embs, t_embs=projected_tails_pos)
         neg_scores = self._compute_scores(h_embs=projected_heads_neg, r_embs=neg_rel_embs, t_embs=projected_tails_neg)
 
-        loss = self._compute_loss(pos_scores=pos_scores, neg_scores=neg_scores)
+        loss = self._compute_loss(positive_scores=pos_scores, negative_scores=neg_scores)
 
         return loss

--- a/src/pykeen/kge_models/trans_h.py
+++ b/src/pykeen/kge_models/trans_h.py
@@ -5,7 +5,6 @@
 from dataclasses import dataclass
 from typing import Dict
 
-import numpy as np
 import torch
 import torch.autograd
 from torch import nn

--- a/src/pykeen/kge_models/trans_h.py
+++ b/src/pykeen/kge_models/trans_h.py
@@ -109,14 +109,8 @@ class TransH(BaseModule):
 
         return soft_constraints_loss
 
-    def compute_loss(self, pos_scores, neg_scores):
-        pos_scores = torch.tensor(pos_scores, dtype=torch.float, device=self.device)
-        neg_scores = torch.tensor(neg_scores, dtype=torch.float, device=self.device)
-
-        # y == -1 indicates that second input to criterion should get a larger loss
-        y = np.repeat([-1], repeats=pos_scores.shape[0])
-        y = torch.tensor(y, dtype=torch.float, device=self.device)
-        margin_ranking_loss = self.criterion(pos_scores, neg_scores, y)
+    def _compute_loss(self, positive_scores, negative_scores):
+        margin_ranking_loss = super(TransH, self)._compute_loss(positive_scores=positive_scores, negative_scores=negative_scores)
         soft_constraint_loss = self.compute_soft_constraint_loss()
 
         loss = margin_ranking_loss + soft_constraint_loss
@@ -176,6 +170,6 @@ class TransH(BaseModule):
         pos_scores = self._compute_scores(h_embs=projected_heads_pos, r_embs=pos_rel_embs, t_embs=projected_tails_pos)
         neg_scores = self._compute_scores(h_embs=projected_heads_neg, r_embs=neg_rel_embs, t_embs=projected_tails_neg)
 
-        loss = self.compute_loss(pos_scores=pos_scores, neg_scores=neg_scores)
+        loss = self._compute_loss(pos_scores=pos_scores, neg_scores=neg_scores)
 
         return loss

--- a/src/pykeen/kge_models/trans_h_adapted_loss.py
+++ b/src/pykeen/kge_models/trans_h_adapted_loss.py
@@ -2,7 +2,6 @@
 
 """Implementation of TransH."""
 
-import numpy as np
 import torch
 import torch.autograd
 import torch.nn as nn

--- a/src/pykeen/kge_models/trans_h_adapted_loss.py
+++ b/src/pykeen/kge_models/trans_h_adapted_loss.py
@@ -103,21 +103,15 @@ class TransH(nn.Module):
 
         return soft_constraints_loss
 
-    def compute_loss(self, pos_scores, neg_scores, batch_entities, batch_relations):
+    def compute_loss(self, positive_scores, negative_scores, batch_entities, batch_relations):
         """
 
-        :param pos_scores:
-        :param neg_scores:
+        :param positive_scores:
+        :param negative_scores:
         :return:
         """
 
-        pos_scores = torch.tensor(pos_scores, dtype=torch.float, device=self.device)
-        neg_scores = torch.tensor(neg_scores, dtype=torch.float, device=self.device)
-
-        # y == -1 indicates that second input to criterion should get a larger loss
-        y = np.repeat([-1], repeats=pos_scores.shape[0])
-        y = torch.tensor(y, dtype=torch.float, device=self.device)
-        margin_ranking_loss = self.criterion(pos_scores, neg_scores, y)
+        margin_ranking_loss = super(TransH, self)._compute_loss(positive_scores=positive_scores, negative_scores=negative_scores)
         soft_constraint_loss = self.compute_soft_constraint_loss(batch_entities, batch_relations)
 
         loss = margin_ranking_loss + soft_constraint_loss
@@ -200,6 +194,6 @@ class TransH(nn.Module):
             batch_entities = batch_entities.cuda()
             batch_relations = batch_relations.cuda()
 
-        loss = self.compute_loss(pos_scores=pos_scores, neg_scores=neg_scores, batch_entities=batch_entities,
+        loss = self.compute_loss(positive_scores=pos_scores, negative_scores=neg_scores, batch_entities=batch_entities,
                                  batch_relations=batch_relations)
         return loss

--- a/src/pykeen/kge_models/trans_r.py
+++ b/src/pykeen/kge_models/trans_r.py
@@ -87,22 +87,6 @@ class TransR(BaseModule):
         distances = torch.mul(distances, distances)
         return distances
 
-    def _compute_loss(self, pos_scores, neg_scores):
-        # y == -1 indicates that second input to criterion should get a larger loss
-        # y = torch.Tensor([-1]).cuda()
-        # NOTE: y = 1 is important
-        # y = torch.tensor([-1], dtype=torch.float, device=self.device)
-        y = np.repeat([-1], repeats=pos_scores.shape[0])
-        y = torch.tensor(y, dtype=torch.float, device=self.device)
-
-        # Scores for the psotive and negative triples
-        pos_scores = torch.tensor(pos_scores, dtype=torch.float, device=self.device)
-        neg_scores = torch.tensor(neg_scores, dtype=torch.float, device=self.device)
-        # neg_scores_temp = 1 * torch.tensor(neg_scores, dtype=torch.float, device=self.device)
-
-        loss = self.criterion(pos_scores, neg_scores, y)
-        return loss
-
     def _project_entities(self, entity_embs, projection_matrix_embs):
         projected_entity_embs = torch.einsum('nk,nkd->nd', [entity_embs, projection_matrix_embs])
         projected_entity_embs = torch.clamp(projected_entity_embs, max=1.)
@@ -158,5 +142,5 @@ class TransR(BaseModule):
         pos_scores = self._compute_scores(h_embs=proj_pos_heads_embs, r_embs=pos_r_embs, t_embs=proj_pos_tails_embs)
         neg_scores = self._compute_scores(h_embs=proj_neg_heads_embs, r_embs=neg_r_embs, t_embs=proj_neg_tails_embs)
 
-        loss = self._compute_loss(pos_scores=pos_scores, neg_scores=neg_scores)
+        loss = self._compute_loss(positive_scores=pos_scores, negative_scores=neg_scores)
         return loss

--- a/src/pykeen/kge_models/unstructured_model.py
+++ b/src/pykeen/kge_models/unstructured_model.py
@@ -57,19 +57,7 @@ class UnstructuredModel(BaseModule):
         # Normalize embeddings of entities
         pos_scores = self._score_triples(batch_positives)
         neg_scores = self._score_triples(batch_negatives)
-        loss = self._compute_loss(pos_scores=pos_scores, neg_scores=neg_scores)
-        return loss
-
-    def _compute_loss(self, pos_scores, neg_scores):
-        y = np.repeat([-1], repeats=pos_scores.shape[0])
-        y = torch.tensor(y, dtype=torch.float, device=self.device)
-
-        # Scores for the psotive and negative triples
-        pos_scores = torch.tensor(pos_scores, dtype=torch.float, device=self.device)
-        neg_scores = torch.tensor(neg_scores, dtype=torch.float, device=self.device)
-        # neg_scores_temp = 1 * torch.tensor(neg_scores, dtype=torch.float, device=self.device)
-
-        loss = self.criterion(pos_scores, neg_scores, y)
+        loss = self._compute_loss(positive_scores=pos_scores, negative_scores=neg_scores)
         return loss
 
     def _score_triples(self, triples):


### PR DESCRIPTION
I moved `_compute_loss` to the base class of all KGE models, as it was an exact duplicate code in all KGE models, except the two TransH models.

I would furthermore propose to remove

```
# Scores for the psotive and negative triples
positive_scores = torch.tensor(positive_scores, dtype=torch.float, device=self.device)
negative_scores = torch.tensor(negative_scores, dtype=torch.float, device=self.device)
```

as it prevents upgrading to the current pytorch release 1.1 due to
```
RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn
```
e.g. when using the notebook for training TransE
```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-10-c7a83f0f10a4> in <module>
      1 results = pykeen.run(
      2     config=config,
----> 3     output_directory=output_directory,
      4 )

/tmp/new/PyKEEN/src/pykeen/run.py in run(config, output_directory)
    139 
    140     pipeline = Pipeline(config=config)
--> 141     results = pipeline.run()
    142 
    143     # Export experimental artifacts

/tmp/new/PyKEEN/src/pykeen/utilities/pipeline.py in run(self)
    102                 pos_triples=mapped_pos_train_triples,
    103                 device=self.device,
--> 104                 seed=self.seed,
    105             )
    106 

/tmp/new/PyKEEN/src/pykeen/utilities/train_utils.py in train_kge_model(kge_model, all_entities, learning_rate, num_epochs, batch_size, pos_triples, device, seed, tqdm_kwargs)
     63         device=device,
     64         seed=seed,
---> 65         tqdm_kwargs=tqdm_kwargs,
     66     )
     67 

/tmp/new/PyKEEN/src/pykeen/utilities/train_utils.py in _train_basic_model(kge_model, all_entities, learning_rate, num_epochs, batch_size, pos_triples, device, seed, tqdm_kwargs)
    135             current_epoch_loss += (loss.item() * current_batch_size)
    136 
--> 137             loss.backward()
    138             optimizer.step()
    139 

~/anaconda3/envs/pykeen/lib/python3.7/site-packages/torch/tensor.py in backward(self, gradient, retain_graph, create_graph)
    105                 products. Defaults to ``False``.
    106         """
--> 107         torch.autograd.backward(self, gradient, retain_graph, create_graph)
    108 
    109     def register_hook(self, hook):

~/anaconda3/envs/pykeen/lib/python3.7/site-packages/torch/autograd/__init__.py in backward(tensors, grad_tensors, retain_graph, create_graph, grad_variables)
     91     Variable._execution_engine.run_backward(
     92         tensors, grad_tensors, retain_graph, create_graph,
---> 93         allow_unreachable=True)  # allow_unreachable flag
     94 
     95 

RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn
```

As I am not sure if there is some case where you would expect to be able to pass non-Tensors to the (protected) method `_compute_loss`, I am waiting for your feedback on that, @mali-git .