### PR TITLE
Compatibility with pytorch 1.1

### DIFF
--- a/src/pykeen/kge_models/base.py
+++ b/src/pykeen/kge_models/base.py
@@ -96,11 +96,6 @@ class BaseModule(nn.Module):
         y = np.repeat([-1], repeats=positive_scores.shape[0])
         y = torch.tensor(y, dtype=torch.float, device=self.device)
 
-        # Scores for the psotive and negative triples
-        positive_scores = torch.tensor(positive_scores, dtype=torch.float, device=self.device)
-        negative_scores = torch.tensor(negative_scores, dtype=torch.float, device=self.device)
-        # neg_scores_temp = 1 * torch.tensor(neg_scores, dtype=torch.float, device=self.device)
-
         loss = self.criterion(positive_scores, negative_scores, y)
         return loss
 


### PR DESCRIPTION
```
# Scores for the psotive and negative triples
positive_scores = torch.tensor(positive_scores, dtype=torch.float, device=self.device)
negative_scores = torch.tensor(negative_scores, dtype=torch.float, device=self.device)
```
prevents from upgrading to the current pytorch release 1.1 due to
```
RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn
```
e.g. when using the notebook for training TransE
```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-10-c7a83f0f10a4> in <module>
      1 results = pykeen.run(
      2     config=config,
----> 3     output_directory=output_directory,
      4 )

/tmp/new/PyKEEN/src/pykeen/run.py in run(config, output_directory)
    139 
    140     pipeline = Pipeline(config=config)
--> 141     results = pipeline.run()
    142 
    143     # Export experimental artifacts

/tmp/new/PyKEEN/src/pykeen/utilities/pipeline.py in run(self)
    102                 pos_triples=mapped_pos_train_triples,
    103                 device=self.device,
--> 104                 seed=self.seed,
    105             )
    106 

/tmp/new/PyKEEN/src/pykeen/utilities/train_utils.py in train_kge_model(kge_model, all_entities, learning_rate, num_epochs, batch_size, pos_triples, device, seed, tqdm_kwargs)
     63         device=device,
     64         seed=seed,
---> 65         tqdm_kwargs=tqdm_kwargs,
     66     )
     67 

/tmp/new/PyKEEN/src/pykeen/utilities/train_utils.py in _train_basic_model(kge_model, all_entities, learning_rate, num_epochs, batch_size, pos_triples, device, seed, tqdm_kwargs)
    135             current_epoch_loss += (loss.item() * current_batch_size)
    136 
--> 137             loss.backward()
    138             optimizer.step()
    139 

~/anaconda3/envs/pykeen/lib/python3.7/site-packages/torch/tensor.py in backward(self, gradient, retain_graph, create_graph)
    105                 products. Defaults to ``False``.
    106         """
--> 107         torch.autograd.backward(self, gradient, retain_graph, create_graph)
    108 
    109     def register_hook(self, hook):

~/anaconda3/envs/pykeen/lib/python3.7/site-packages/torch/autograd/__init__.py in backward(tensors, grad_tensors, retain_graph, create_graph, grad_variables)
     91     Variable._execution_engine.run_backward(
     92         tensors, grad_tensors, retain_graph, create_graph,
---> 93         allow_unreachable=True)  # allow_unreachable flag
     94 
     95 
```